### PR TITLE
Broken link has been removed

### DIFF
--- a/content/en/about-configuring-jsdoc.md
+++ b/content/en/about-configuring-jsdoc.md
@@ -44,9 +44,6 @@ module.exports = {
 
 {% endexample %}
 
-For a more comprehensive example of a JSON configuration file, see the file
-[`conf.json.EXAMPLE`][conf-json-example].
-
 [about-commandline]: about-commandline.html
 [conf-json-example]: https://github.com/jsdoc3/jsdoc/blob/master/conf.json.EXAMPLE
 [markdown]: plugins-markdown.html


### PR DESCRIPTION
I found a broken link in the documentation. The link pointed to a document that no longer exists.