### PR TITLE
Fix the link to the conf.json.EXAMPLE

### DIFF
--- a/about-configuring-jsdoc.html
+++ b/about-configuring-jsdoc.html
@@ -80,7 +80,7 @@ module.exports = {
 </code></pre>
     </figure>
     <p>For a more comprehensive example of a JSON configuration file, see the file
-      <a href="https://github.com/jsdoc3/jsdoc/blob/master/conf.json.EXAMPLE"><code>conf.json.EXAMPLE</code></a>.</p>
+      <a href="https://github.com/jsdoc/jsdoc/blob/master/packages/jsdoc/conf.json.EXAMPLE"><code>conf.json.EXAMPLE</code></a>.</p>
     <h2 id="default-configuration-options">Default configuration options</h2>
     <p>If you do not specify a configuration file, JSDoc uses the following configuration options:</p>
     <figure>


### PR DESCRIPTION
The link to `conf.json.EXAMPLE` on https://jsdoc.app/about-configuring-jsdoc.html is broken.  I think it should be pointing to https://github.com/jsdoc/jsdoc/blob/master/packages/jsdoc/conf.json.EXAMPLE.  That's the only `conf.json.EXAMPLE` I could find.