### PR TITLE
Fix broken HTML for promise resolve type added in #7491db0

### DIFF
--- a/content/en/tags-returns.md
+++ b/content/en/tags-returns.md
@@ -81,7 +81,7 @@ function sum(a, b, retArr) {
  * Returns the sum of a and b
  * @param {number} a
  * @param {number} b
- * @returns {Promise<number>} Promise object represents the sum of a and b
+ * @returns {Promise&lt;number&gt;} Promise object represents the sum of a and b
  */
 function sumAsync(a, b) {
     return new Promise(function(resolve, reject) {

--- a/tags-returns.html
+++ b/tags-returns.html
@@ -96,7 +96,7 @@ function sum(a, b, retArr) {
  * Returns the sum of a and b
  * @param {number} a
  * @param {number} b
- * @returns {Promise<number>} Promise object represents the sum of a and b
+ * @returns {Promise&lt;number&gt;} Promise object represents the sum of a and b
  */
 function sumAsync(a, b) {
     return new Promise(function(resolve, reject) {


### PR DESCRIPTION
The `@returns` tag [documentation](https://jsdoc.app/tags-returns.html) has a broken example for promises. This PR updates the example so the promise resolve type will show.