### PR TITLE
Regenerate site (which updates copyright message dates)

### DIFF
--- a/about-block-inline-tags.html
+++ b/about-block-inline-tags.html
@@ -91,7 +91,7 @@ Shoe.prototype.setLaceType = function(color, type) {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/about-commandline.html
+++ b/about-commandline.html
@@ -156,7 +156,7 @@
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/about-configuring-default-template.html
+++ b/about-configuring-default-template.html
@@ -110,7 +110,7 @@
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/about-configuring-jsdoc.html
+++ b/about-configuring-jsdoc.html
@@ -343,7 +343,7 @@ module.exports = {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/about-getting-started.html
+++ b/about-getting-started.html
@@ -94,7 +94,7 @@ function Book(title, author) {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/about-including-package.html
+++ b/about-including-package.html
@@ -48,7 +48,7 @@
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/about-including-readme.html
+++ b/about-including-readme.html
@@ -46,7 +46,7 @@
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/about-license-jsdoc3.html
+++ b/about-license-jsdoc3.html
@@ -28,7 +28,7 @@
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/about-namepaths.html
+++ b/about-namepaths.html
@@ -157,7 +157,7 @@ var chat = {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/about-plugins.html
+++ b/about-plugins.html
@@ -366,7 +366,7 @@ exports.handlers = {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/about-tutorials.html
+++ b/about-tutorials.html
@@ -155,7 +155,7 @@ function Socket() {}
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/howto-amd-modules.html
+++ b/howto-amd-modules.html
@@ -247,7 +247,7 @@ define('tag', function() {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/howto-commonjs-modules.html
+++ b/howto-commonjs-modules.html
@@ -345,7 +345,7 @@ this.Book = function(title) {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/howto-es2015-classes.html
+++ b/howto-es2015-classes.html
@@ -127,7 +127,7 @@ class Dot extends Point {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/howto-es2015-modules.html
+++ b/howto-es2015-modules.html
@@ -103,7 +103,7 @@ export {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/index.html
+++ b/index.html
@@ -215,7 +215,7 @@
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/plugins-markdown.html
+++ b/plugins-markdown.html
@@ -119,7 +119,7 @@
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-abstract.html
+++ b/tags-abstract.html
@@ -76,7 +76,7 @@ Milk.prototype.isSolid = function() {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-access.html
+++ b/tags-access.html
@@ -122,7 +122,7 @@ function OtherThingy() {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-alias.html
+++ b/tags-alias.html
@@ -165,7 +165,7 @@ var objectB = (function() {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-async.html
+++ b/tags-async.html
@@ -61,7 +61,7 @@
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-augments.html
+++ b/tags-augments.html
@@ -151,7 +151,7 @@ Duck.prototype.takeOff = function() {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-author.html
+++ b/tags-author.html
@@ -62,7 +62,7 @@ function MyClass() {}
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-borrows.html
+++ b/tags-borrows.html
@@ -62,7 +62,7 @@ function trstr(str) {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-callback.html
+++ b/tags-callback.html
@@ -106,7 +106,7 @@ Requester.prototype.send = function(cb) {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-class.html
+++ b/tags-class.html
@@ -67,7 +67,7 @@ var p = new Person();
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-classdesc.html
+++ b/tags-classdesc.html
@@ -71,7 +71,7 @@ function MyClass() {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-constant.html
+++ b/tags-constant.html
@@ -78,7 +78,7 @@ var ONE = 1;
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-constructs.html
+++ b/tags-constructs.html
@@ -82,7 +82,7 @@
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-copyright.html
+++ b/tags-copyright.html
@@ -53,7 +53,7 @@
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-default.html
+++ b/tags-default.html
@@ -61,7 +61,7 @@ const RED = 0xff0000;
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-deprecated.html
+++ b/tags-deprecated.html
@@ -51,7 +51,7 @@ function old() {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-description.html
+++ b/tags-description.html
@@ -92,7 +92,7 @@ function add(a, b) {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-enum.html
+++ b/tags-enum.html
@@ -70,7 +70,7 @@ var triState = {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-event.html
+++ b/tags-event.html
@@ -105,7 +105,7 @@ Hurl.prototype.snowball = function() {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-example.html
+++ b/tags-example.html
@@ -69,7 +69,7 @@ globalNS.method1 = function (a, b) {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-exports.html
+++ b/tags-exports.html
@@ -152,7 +152,7 @@ module.exports = function() {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-external.html
+++ b/tags-external.html
@@ -128,7 +128,7 @@
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-file.html
+++ b/tags-file.html
@@ -68,7 +68,7 @@
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-fires.html
+++ b/tags-fires.html
@@ -72,7 +72,7 @@ Milkshake.prototype.drink = function() {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-function.html
+++ b/tags-function.html
@@ -71,7 +71,7 @@ var paginate = paginateFactory(pages);
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-generator.html
+++ b/tags-generator.html
@@ -58,7 +58,7 @@
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-global.html
+++ b/tags-global.html
@@ -66,7 +66,7 @@
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-hideconstructor.html
+++ b/tags-hideconstructor.html
@@ -134,7 +134,7 @@ class WaffleIron {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-ignore.html
+++ b/tags-ignore.html
@@ -79,7 +79,7 @@ var Clothes = {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-implements.html
+++ b/tags-implements.html
@@ -99,7 +99,7 @@ TransparentColor.prototype.rgba = function() {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-inheritdoc.html
+++ b/tags-inheritdoc.html
@@ -106,7 +106,7 @@ Socket.prototype.open = function() {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-inline-link.html
+++ b/tags-inline-link.html
@@ -122,7 +122,7 @@ property&lt;/a>. Also, check out &lt;a href="http://www.google.com">Google&lt;/a
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-inline-tutorial.html
+++ b/tags-inline-tutorial.html
@@ -76,7 +76,7 @@ For more information, see &lt;a href="tutorial-create.html">Creating a Widget&lt
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-inner.html
+++ b/tags-inner.html
@@ -81,7 +81,7 @@ var MyNamespace = {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-instance.html
+++ b/tags-instance.html
@@ -85,7 +85,7 @@ function fooFactory(fooValue) {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-interface.html
+++ b/tags-interface.html
@@ -104,7 +104,7 @@ Color.prototype.rgb = function() {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-kind.html
+++ b/tags-kind.html
@@ -99,7 +99,7 @@ const asdf = 1;
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-lends.html
+++ b/tags-lends.html
@@ -161,7 +161,7 @@ var Person = makeClass(
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-license.html
+++ b/tags-license.html
@@ -82,7 +82,7 @@
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-listens.html
+++ b/tags-listens.html
@@ -108,7 +108,7 @@ define('playground/monitor', [], function () {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-member.html
+++ b/tags-member.html
@@ -73,7 +73,7 @@ var foo;
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-memberof.html
+++ b/tags-memberof.html
@@ -135,7 +135,7 @@ function Data() {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-mixes.html
+++ b/tags-mixes.html
@@ -104,7 +104,7 @@ mix(Eventful).into(FormButton.prototype);
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-mixin.html
+++ b/tags-mixin.html
@@ -86,7 +86,7 @@ var Eventful = {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-module.html
+++ b/tags-module.html
@@ -117,7 +117,7 @@ exports.darken = function (color, shade) {};
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-name.html
+++ b/tags-name.html
@@ -74,7 +74,7 @@ eval("window.highlightSearchTerm = function(term) {};")
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-namespace.html
+++ b/tags-namespace.html
@@ -96,7 +96,7 @@ window["!"] = function(msg) { alert(msg); };
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-override.html
+++ b/tags-override.html
@@ -80,7 +80,7 @@ Socket.prototype.open = function() {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-package.html
+++ b/tags-package.html
@@ -88,7 +88,7 @@ function Thingy() {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-param.html
+++ b/tags-param.html
@@ -289,7 +289,7 @@ function doSomethingAsynchronously(cb) {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-private.html
+++ b/tags-private.html
@@ -96,7 +96,7 @@ var Documents = {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-property.html
+++ b/tags-property.html
@@ -96,7 +96,7 @@ var config = {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-protected.html
+++ b/tags-protected.html
@@ -87,7 +87,7 @@ function Thingy() {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-public.html
+++ b/tags-public.html
@@ -86,7 +86,7 @@ function Thingy() {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-readonly.html
+++ b/tags-readonly.html
@@ -68,7 +68,7 @@ var pieOptions = {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-requires.html
+++ b/tags-requires.html
@@ -57,7 +57,7 @@ function Widgetizer() {}
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-returns.html
+++ b/tags-returns.html
@@ -119,7 +119,7 @@ function sumAsync(a, b) {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-see.html
+++ b/tags-see.html
@@ -69,7 +69,7 @@ function bar() {}
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-since.html
+++ b/tags-since.html
@@ -56,7 +56,7 @@ function UserRecord() {}
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-static.html
+++ b/tags-static.html
@@ -79,7 +79,7 @@ var wheel = 1;
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-summary.html
+++ b/tags-summary.html
@@ -60,7 +60,7 @@ function bloviate() {}
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-this.html
+++ b/tags-this.html
@@ -60,7 +60,7 @@ function setName(name) {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-throws.html
+++ b/tags-throws.html
@@ -76,7 +76,7 @@ function baz(x) {}
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-todo.html
+++ b/tags-todo.html
@@ -52,7 +52,7 @@ function foo() {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-tutorial.html
+++ b/tags-tutorial.html
@@ -71,7 +71,7 @@ function MyClass() {}
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-type.html
+++ b/tags-type.html
@@ -329,7 +329,7 @@ var FOO = 1;
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-typedef.html
+++ b/tags-typedef.html
@@ -98,7 +98,7 @@ function WishGranter(triforce) {}
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-variation.html
+++ b/tags-variation.html
@@ -95,7 +95,7 @@ Widget.properties = {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-version.html
+++ b/tags-version.html
@@ -56,7 +56,7 @@ function solver(a, b) {
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>

--- a/tags-yields.html
+++ b/tags-yields.html
@@ -77,7 +77,7 @@ function* fibonacci() {}
     <a class="license-badge" href="http://creativecommons.org/licenses/by-sa/3.0/">
       <img alt="Creative Commons License" class="license-badge" src="images/cc-by-sa.svg" width="80" height="15" /></a>
     <br>
-    Copyright &#169; 2011-2017 the
+    Copyright &#169; 2011-2019 the
     <a href="https://github.com/jsdoc3/jsdoc3.github.com/contributors">contributors</a> to the
     JSDoc 3 documentation project.
     <br>


### PR DESCRIPTION
When I created my [other PR](https://github.com/jsdoc/jsdoc.github.io/pull/219), gulp updated the copyright info in all of the rendered pages. I excluded them to keep that PR clean.

This PR submits includes [only] those changes.