### PR TITLE
Fixed broken link JSDoc's plugins directory

### DIFF
--- a/about-configuring-jsdoc.html
+++ b/about-configuring-jsdoc.html
@@ -136,7 +136,7 @@ module.exports = {
 </code></pre>
     </figure>
     <p>See the <a href="about-plugins.html">plugin reference</a> for further information, and look in <a
-        href="https://github.com/jsdoc3/jsdoc/tree/master/plugins">JSDoc&#39;s <code>plugins</code>
+        href="https://github.com/jsdoc/jsdoc/tree/main/packages/jsdoc/plugins">JSDoc&#39;s <code>plugins</code>
         directory</a> for the plugins built into JSDoc.</p>
     <p>You can configure the Markdown plugin by adding a <code>markdown</code> object to your configuration file. See
       <a href="plugins-markdown.html">Configuring the Markdown Plugin</a> for details.</p>


### PR DESCRIPTION
Fixed broken link with old route to plugins

Old broken link is not found 

The plugin folder was moved, I found its new localization and by comparing a stale we can assure, that they indeed contain the same files

Stale backup
https://github.com/jsdoc/jsdoc/tree/next/plugins

Old broken link
https://github.com/jsdoc3/jsdoc/tree/master/plugins

Current
https://github.com/jsdoc/jsdoc/tree/main/packages/jsdoc/plugins

The directories were changed in this
jsdoc/jsdoc@b970691
