### PR TITLE
Fix error tags-inline-link.md

### DIFF
--- a/content/tags-inline-link.md
+++ b/content/tags-inline-link.md
@@ -14,7 +14,7 @@ related:
 ## Syntax
 
     {@link namepathOrURL}
-    [link text]{@link namepathOrURL}
+    [link text]({@link namepathOrURL})
     {@link namepathOrURL|link text}
     {@link namepathOrURL link text (after the first space)}
 
@@ -63,7 +63,7 @@ The following example shows all of the ways to provide link text for the `{@link
 
 ```js
 /**
- * See {@link MyClass} and [MyClass's foo property]{@link MyClass#foo}.
+ * See {@link MyClass} and [MyClass's foo property]({@link MyClass#foo}).
  * Also, check out {@link http://www.google.com|Google} and
  * {@link https://github.com GitHub}.
  */


### PR DESCRIPTION
Fix an error when using link in a markdown style where instead of using straight as []{@link linkHere }  you should rather use it as []({@link linkHere })

Note:
This was not rendering as expected in my editor:
VsCode

Details about VScode:

Version: 1.87.0 (user setup)
Commit: 019f4d1419fbc8219a181fab7892ebccf7ee29a2
Date: 2024-02-27T23:41:44.469Z
Electron: 27.3.2
ElectronBuildId: 26836302
Chromium: 118.0.5993.159
Node.js: 18.17.1
V8: 11.8.172.18-electron.0
OS: Windows_NT x64 10.0.22631

Added context
I was using it with typescript when seeing this error, so I am not sure if the might be something with the typescript LSP

Using it the recommended way results in the following:
![image](https://github.com/jsdoc/jsdoc.github.io/assets/74509303/7b613278-950b-4c1d-8ff0-191e6c26e64d)

Using it in the []({@link LinkHere}) way results in:
![image](https://github.com/jsdoc/jsdoc.github.io/assets/74509303/e1f05561-89ab-4c24-9bdc-b5e0a734f2bb)
